### PR TITLE
Use IPAddress.h instead of Ethernet.h

### DIFF
--- a/src/IniFile.h
+++ b/src/IniFile.h
@@ -8,7 +8,7 @@
 #define INI_FILE_MAX_FILENAME_LEN 26
 
 #include "SD.h"
-#include "Ethernet.h"
+#include "IPAddress.h"
 
 class IniFileState;
 


### PR DESCRIPTION
The only reason for including Ethernet.h was to bring in IPAddress.h, so cut out the middleman. This allows the library to be compatible with any network library. For example, previously if you tried to use IniFile with the Ethernet2 library compilation would fail with "multiple definition" errors.

Fixes https://github.com/stevemarple/IniFile/issues/12

CC: @MSauerland