### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,28 +5,28 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-IniFile		KEYWORD1
+IniFile	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-clearError			KEYWORD2
-close				KEYWORD2
-isOpen				KEYWORD2
-getCaseSensitive		KEYWORD2
-getError			KEYWORD2
-getFilename			KEYWORD2
-getIPAddress			KEYWORD2
-getMACAddress			KEYWORD2
-getMode				KEYWORD2
-getValue			KEYWORD2
-isCommentChar			KEYWORD2
-open				KEYWORD2
-readLine			KEYWORD2
+clearError	KEYWORD2
+close	KEYWORD2
+isOpen	KEYWORD2
+getCaseSensitive	KEYWORD2
+getError	KEYWORD2
+getFilename	KEYWORD2
+getIPAddress	KEYWORD2
+getMACAddress	KEYWORD2
+getMode	KEYWORD2
+getValue	KEYWORD2
+isCommentChar	KEYWORD2
+open	KEYWORD2
+readLine	KEYWORD2
 removeTrailingWhiteSpace	KEYWORD2
-setCaseSensitive		KEYWORD2
-skipWhiteSpace			KEYWORD2
-validate			KEYWORD2
+setCaseSensitive	KEYWORD2
+skipWhiteSpace	KEYWORD2
+validate	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords