### PR TITLE
Added support for FatFileSystem (not only SD-Card)

### DIFF
--- a/src/IniFile.h
+++ b/src/IniFile.h
@@ -4,10 +4,14 @@
 #include <stdint.h>
 
 #if defined(PREFER_SDFAT_LIBRARY)
-#include "SdFat.h"
-extern SdFat SD;
+	#include "SdFat.h"
+	#if defined(PREFER_FAT_FILE_SYSTEM)
+	extern FatFileSystem fatfs;
+	#else
+	extern SdFat SD;
+	#endif
 #else
-#include "SD.h"
+	#include "SD.h"
 #endif
 #include "IPAddress.h"
 
@@ -155,7 +159,11 @@ bool IniFile::open(void)
 {
 	if (_file)
 		_file.close();
+#if defined(PREFER_FAT_FILE_SYSTEM)
+	_file = fatfs.open(_filename, _mode);
+#else
 	_file = SD.open(_filename, _mode);
+#endif
 	if (isOpen()) {
 		_error = errorNoError;
 		return true;


### PR DESCRIPTION
If the keyword "PREFER_FAT_FILE_SYSTEM" is defined in addition to "PREFER_SDFAT_LIBRARY", ini-Files can be opened from a locally mounted fat file system instead of an external SD-Card. This can be useful when working with Adafruits SPI-Flash library.