### PR TITLE
Made possible to use SD_MMC library

### DIFF
--- a/src/IniFile.h
+++ b/src/IniFile.h
@@ -6,6 +6,8 @@
 #if defined(PREFER_SDFAT_LIBRARY)
 #include "SdFat.h"
 extern SdFat SD;
+#elif defined(PREFER_SD_MMC_LIBRARY)
+#include <SD_MMC.h>
 #else
 #include "SD.h"
 #endif
@@ -155,7 +157,11 @@ bool IniFile::open(void)
 {
 	if (_file)
 		_file.close();
+	#if defined(PREFER_SD_MMC_LIBRARY)
+	_file = SD_MMC.open(_filename, _mode);
+	#else
 	_file = SD.open(_filename, _mode);
+	#endif
 	if (isOpen()) {
 		_error = errorNoError;
 		return true;


### PR DESCRIPTION
Made possible the use SD_MMC library by defining PREFER_SD_MMC_LIBRARY. This is an alternative to the SPI and SD library used as default.